### PR TITLE
Show EL transactions on slot details page

### DIFF
--- a/cmd/explorer/main.go
+++ b/cmd/explorer/main.go
@@ -50,6 +50,10 @@ func main() {
 	if err != nil {
 		logger.Fatalf("error starting beacon service: %v", err)
 	}
+	err = services.StartTxSignaturesService()
+	if err != nil {
+		logger.Fatalf("error starting tx signature service: %v", err)
+	}
 
 	if cfg.RateLimit.Enabled {
 		err = services.StartCallRateLimiter(cfg.RateLimit.ProxyCount, cfg.RateLimit.Rate, cfg.RateLimit.Burst)

--- a/db/db.go
+++ b/db/db.go
@@ -955,3 +955,109 @@ func GetLatestBlobAssignment(commitment []byte) *dbtypes.BlobAssignment {
 	}
 	return &blobAssignment
 }
+
+func GetTxFunctionSignaturesByBytes(sigBytes [][]byte) []*dbtypes.TxFunctionSignature {
+	fnSigs := []*dbtypes.TxFunctionSignature{}
+
+	var sql strings.Builder
+	fmt.Fprintf(&sql, `
+	SELECT
+		signature, bytes, name
+	FROM tx_function_signatures
+	WHERE bytes IN (`)
+	argIdx := 0
+	args := make([]any, len(sigBytes))
+	for i, b := range sigBytes {
+		if i > 0 {
+			fmt.Fprintf(&sql, ", ")
+		}
+		fmt.Fprintf(&sql, "$%v", argIdx+1)
+		args[argIdx] = b
+		argIdx += 1
+	}
+	fmt.Fprintf(&sql, ")")
+
+	err := ReaderDb.Select(&fnSigs, sql.String(), sigBytes)
+	if err != nil {
+		logger.Errorf("Error while fetching tx function signatures: %v", err)
+		return nil
+	}
+	return fnSigs
+}
+
+func InsertTxFunctionSignature(txFuncSig *dbtypes.TxFunctionSignature, tx *sqlx.Tx) error {
+	_, err := tx.Exec(EngineQuery(map[dbtypes.DBEngineType]string{
+		dbtypes.DBEnginePgsql: `
+			INSERT INTO tx_function_signatures (
+				signature, bytes, name
+			) VALUES ($1, $2, $3)
+			ON CONFLICT (signature) DO NOTHING`,
+		dbtypes.DBEngineSqlite: `
+			INSERT OR IGNORE INTO tx_function_signatures (
+				signature, bytes, name
+			) VALUES ($1, $2, $3)`,
+	}),
+		txFuncSig.Signature, txFuncSig.Bytes, txFuncSig.Name)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func GetUnknownFunctionSignatures(sigBytes [][]byte) []*dbtypes.TxUnknownFunctionSignature {
+	unknwonFnSigs := []*dbtypes.TxUnknownFunctionSignature{}
+	if len(sigBytes) == 0 {
+		return unknwonFnSigs
+	}
+	var sql strings.Builder
+	fmt.Fprintf(&sql, `
+	SELECT
+		bytes, lastcheck
+	FROM tx_unknown_signatures
+	WHERE bytes in (`)
+	argIdx := 0
+	args := make([]any, len(sigBytes))
+	for i, b := range sigBytes {
+		if i > 0 {
+			fmt.Fprintf(&sql, ", ")
+		}
+		fmt.Fprintf(&sql, "$%v", argIdx+1)
+		args[argIdx] = b
+		argIdx += 1
+	}
+	fmt.Fprintf(&sql, ")")
+	err := ReaderDb.Select(&unknwonFnSigs, sql.String(), args...)
+	if err != nil {
+		logger.Errorf("Error while fetching unknown function signatures: %v", err)
+		return nil
+	}
+	return unknwonFnSigs
+}
+
+func InsertUnknownFunctionSignatures(txUnknownSigs []*dbtypes.TxUnknownFunctionSignature, tx *sqlx.Tx) error {
+	var sql strings.Builder
+	fmt.Fprint(&sql, EngineQuery(map[dbtypes.DBEngineType]string{
+		dbtypes.DBEnginePgsql:  `INSERT INTO tx_unknown_signatures (bytes, lastcheck) VALUES `,
+		dbtypes.DBEngineSqlite: `INSERT OR REPLACE INTO tx_unknown_signatures (bytes, lastcheck) VALUES `,
+	}))
+	argIdx := 0
+	args := make([]any, len(txUnknownSigs)*2)
+	for i, unknownSig := range txUnknownSigs {
+		if i > 0 {
+			fmt.Fprintf(&sql, ", ")
+		}
+		fmt.Fprintf(&sql, "($%v, $%v)", argIdx+1, argIdx+2)
+		args[argIdx] = unknownSig.Bytes
+		args[argIdx+1] = unknownSig.LastCheck
+		argIdx += 2
+	}
+	fmt.Fprint(&sql, EngineQuery(map[dbtypes.DBEngineType]string{
+		dbtypes.DBEnginePgsql:  ` ON CONFLICT (bytes) DO UPDATE SET lastcheck = excluded.lastcheck`,
+		dbtypes.DBEngineSqlite: "",
+	}))
+	_, err := tx.Exec(sql.String(), args...)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/db/db.go
+++ b/db/db.go
@@ -967,12 +967,12 @@ func GetTxFunctionSignaturesByBytes(sigBytes []types.TxSignatureBytes) []*dbtype
 	WHERE bytes IN (`)
 	argIdx := 0
 	args := make([]any, len(sigBytes))
-	for i, b := range sigBytes {
+	for i := range sigBytes {
 		if i > 0 {
 			fmt.Fprintf(&sql, ", ")
 		}
 		fmt.Fprintf(&sql, "$%v", argIdx+1)
-		args[argIdx] = b[:]
+		args[argIdx] = sigBytes[i][:]
 		argIdx += 1
 	}
 	fmt.Fprintf(&sql, ")")
@@ -1017,12 +1017,12 @@ func GetUnknownFunctionSignatures(sigBytes []types.TxSignatureBytes) []*dbtypes.
 	WHERE bytes in (`)
 	argIdx := 0
 	args := make([]any, len(sigBytes))
-	for i, b := range sigBytes {
+	for i := range sigBytes {
 		if i > 0 {
 			fmt.Fprintf(&sql, ", ")
 		}
 		fmt.Fprintf(&sql, "$%v", argIdx+1)
-		args[argIdx] = b[:]
+		args[argIdx] = sigBytes[i][:]
 		argIdx += 1
 	}
 	fmt.Fprintf(&sql, ")")
@@ -1042,13 +1042,13 @@ func InsertUnknownFunctionSignatures(txUnknownSigs []*dbtypes.TxUnknownFunctionS
 	}))
 	argIdx := 0
 	args := make([]any, len(txUnknownSigs)*2)
-	for i, unknownSig := range txUnknownSigs {
+	for i := range txUnknownSigs {
 		if i > 0 {
 			fmt.Fprintf(&sql, ", ")
 		}
 		fmt.Fprintf(&sql, "($%v, $%v)", argIdx+1, argIdx+2)
-		args[argIdx] = unknownSig.Bytes
-		args[argIdx+1] = unknownSig.LastCheck
+		args[argIdx] = txUnknownSigs[i].Bytes
+		args[argIdx+1] = txUnknownSigs[i].LastCheck
 		argIdx += 2
 	}
 	fmt.Fprint(&sql, EngineQuery(map[dbtypes.DBEngineType]string{
@@ -1070,13 +1070,13 @@ func InsertPendingFunctionSignatures(txPendingSigs []*dbtypes.TxPendingFunctionS
 	}))
 	argIdx := 0
 	args := make([]any, len(txPendingSigs)*2)
-	for i, pendingSig := range txPendingSigs {
+	for i := range txPendingSigs {
 		if i > 0 {
 			fmt.Fprintf(&sql, ", ")
 		}
 		fmt.Fprintf(&sql, "($%v, $%v)", argIdx+1, argIdx+2)
-		args[argIdx] = pendingSig.Bytes
-		args[argIdx+1] = pendingSig.QueueTime
+		args[argIdx] = txPendingSigs[i].Bytes
+		args[argIdx+1] = txPendingSigs[i].QueueTime
 		argIdx += 2
 	}
 	fmt.Fprint(&sql, EngineQuery(map[dbtypes.DBEngineType]string{
@@ -1092,10 +1092,6 @@ func InsertPendingFunctionSignatures(txPendingSigs []*dbtypes.TxPendingFunctionS
 
 func GetPendingFunctionSignatures(limit uint64) []*dbtypes.TxPendingFunctionSignature {
 	pendingFnSigs := []*dbtypes.TxPendingFunctionSignature{}
-	var sql strings.Builder
-	fmt.Fprintf(&sql, `
-	`)
-
 	err := ReaderDb.Select(&pendingFnSigs, `
 	SELECT
 		bytes, queuetime
@@ -1117,15 +1113,13 @@ func DeletePendingFunctionSignatures(sigBytes []types.TxSignatureBytes, tx *sqlx
 	fmt.Fprintf(&sql, `
 	DELETE FROM tx_pending_signatures
 	WHERE bytes in (`)
-	argIdx := 0
 	args := make([]any, len(sigBytes))
-	for i, b := range sigBytes {
+	for i := range sigBytes {
 		if i > 0 {
 			fmt.Fprintf(&sql, ", ")
 		}
-		fmt.Fprintf(&sql, "$%v", argIdx+1)
-		args[argIdx] = b[:]
-		argIdx += 1
+		fmt.Fprintf(&sql, "$%v", i+1)
+		args[i] = sigBytes[i][:]
 	}
 	fmt.Fprintf(&sql, ")")
 	_, err := tx.Exec(sql.String(), args...)

--- a/db/db.go
+++ b/db/db.go
@@ -956,7 +956,7 @@ func GetLatestBlobAssignment(commitment []byte) *dbtypes.BlobAssignment {
 	return &blobAssignment
 }
 
-func GetTxFunctionSignaturesByBytes(sigBytes [][]byte) []*dbtypes.TxFunctionSignature {
+func GetTxFunctionSignaturesByBytes(sigBytes []types.TxSignatureBytes) []*dbtypes.TxFunctionSignature {
 	fnSigs := []*dbtypes.TxFunctionSignature{}
 
 	var sql strings.Builder
@@ -972,12 +972,12 @@ func GetTxFunctionSignaturesByBytes(sigBytes [][]byte) []*dbtypes.TxFunctionSign
 			fmt.Fprintf(&sql, ", ")
 		}
 		fmt.Fprintf(&sql, "$%v", argIdx+1)
-		args[argIdx] = b
+		args[argIdx] = b[:]
 		argIdx += 1
 	}
 	fmt.Fprintf(&sql, ")")
 
-	err := ReaderDb.Select(&fnSigs, sql.String(), sigBytes)
+	err := ReaderDb.Select(&fnSigs, sql.String(), args...)
 	if err != nil {
 		logger.Errorf("Error while fetching tx function signatures: %v", err)
 		return nil
@@ -1004,7 +1004,7 @@ func InsertTxFunctionSignature(txFuncSig *dbtypes.TxFunctionSignature, tx *sqlx.
 	return nil
 }
 
-func GetUnknownFunctionSignatures(sigBytes [][]byte) []*dbtypes.TxUnknownFunctionSignature {
+func GetUnknownFunctionSignatures(sigBytes []types.TxSignatureBytes) []*dbtypes.TxUnknownFunctionSignature {
 	unknwonFnSigs := []*dbtypes.TxUnknownFunctionSignature{}
 	if len(sigBytes) == 0 {
 		return unknwonFnSigs
@@ -1022,7 +1022,7 @@ func GetUnknownFunctionSignatures(sigBytes [][]byte) []*dbtypes.TxUnknownFunctio
 			fmt.Fprintf(&sql, ", ")
 		}
 		fmt.Fprintf(&sql, "$%v", argIdx+1)
-		args[argIdx] = b
+		args[argIdx] = b[:]
 		argIdx += 1
 	}
 	fmt.Fprintf(&sql, ")")

--- a/db/schema/pgsql/20231113161726_tx-method-signatures.sql
+++ b/db/schema/pgsql/20231113161726_tx-method-signatures.sql
@@ -1,0 +1,28 @@
+-- +goose Up
+-- +goose StatementBegin
+
+CREATE TABLE IF NOT EXISTS public."tx_function_signatures"
+(
+    "signature" TEXT NOT NULL,
+    "bytes" bytea NOT NULL,
+    "name" TEXT NOT NULL,
+    PRIMARY KEY ("signature")
+);
+
+CREATE INDEX IF NOT EXISTS "tx_function_signatures_bytes_idx"
+    ON public."tx_function_signatures" 
+    ("bytes" ASC NULLS LAST);
+
+
+CREATE TABLE IF NOT EXISTS public."tx_unknown_signatures"
+(
+    "bytes" bytea NOT NULL,
+    "lastcheck" bigint NOT NULL,
+    PRIMARY KEY ("bytes")
+);
+
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+SELECT 'NOT SUPPORTED';
+-- +goose StatementEnd

--- a/db/schema/pgsql/20231113161726_tx-method-signatures.sql
+++ b/db/schema/pgsql/20231113161726_tx-method-signatures.sql
@@ -3,16 +3,11 @@
 
 CREATE TABLE IF NOT EXISTS public."tx_function_signatures"
 (
-    "signature" TEXT NOT NULL,
     "bytes" bytea NOT NULL,
+    "signature" TEXT NOT NULL,
     "name" TEXT NOT NULL,
-    PRIMARY KEY ("signature")
+    PRIMARY KEY ("bytes")
 );
-
-CREATE INDEX IF NOT EXISTS "tx_function_signatures_bytes_idx"
-    ON public."tx_function_signatures" 
-    ("bytes" ASC NULLS LAST);
-
 
 CREATE TABLE IF NOT EXISTS public."tx_unknown_signatures"
 (

--- a/db/schema/pgsql/20231113161726_tx-method-signatures.sql
+++ b/db/schema/pgsql/20231113161726_tx-method-signatures.sql
@@ -16,6 +16,13 @@ CREATE TABLE IF NOT EXISTS public."tx_unknown_signatures"
     PRIMARY KEY ("bytes")
 );
 
+CREATE TABLE IF NOT EXISTS public."tx_pending_signatures"
+(
+    "bytes" bytea NOT NULL,
+    "queuetime" bigint NOT NULL,
+    PRIMARY KEY ("bytes")
+);
+
 -- +goose StatementEnd
 -- +goose Down
 -- +goose StatementBegin

--- a/db/schema/sqlite/20231113161726_tx-method-signatures.sql
+++ b/db/schema/sqlite/20231113161726_tx-method-signatures.sql
@@ -1,0 +1,27 @@
+-- +goose Up
+-- +goose StatementBegin
+
+CREATE TABLE IF NOT EXISTS "tx_function_signatures"
+(
+    "signature" TEXT NOT NULL,
+    "bytes" BLOB NOT NULL,
+    "name" TEXT NOT NULL,
+    PRIMARY KEY ("signature")
+);
+
+CREATE INDEX IF NOT EXISTS "tx_function_signatures_bytes_idx"
+    ON "tx_function_signatures" 
+    ("bytes" ASC);
+
+CREATE TABLE IF NOT EXISTS "tx_unknown_signatures"
+(
+    "bytes" bytea NOT NULL,
+    "lastcheck" bigint NOT NULL,
+    PRIMARY KEY ("bytes")
+);
+
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+SELECT 'NOT SUPPORTED';
+-- +goose StatementEnd

--- a/db/schema/sqlite/20231113161726_tx-method-signatures.sql
+++ b/db/schema/sqlite/20231113161726_tx-method-signatures.sql
@@ -11,8 +11,15 @@ CREATE TABLE IF NOT EXISTS "tx_function_signatures"
 
 CREATE TABLE IF NOT EXISTS "tx_unknown_signatures"
 (
-    "bytes" bytea NOT NULL,
+    "bytes" BLOB NOT NULL,
     "lastcheck" bigint NOT NULL,
+    PRIMARY KEY ("bytes")
+);
+
+CREATE TABLE IF NOT EXISTS "tx_pending_signatures"
+(
+    "bytes" BLOB NOT NULL,
+    "queuetime" bigint NOT NULL,
     PRIMARY KEY ("bytes")
 );
 

--- a/db/schema/sqlite/20231113161726_tx-method-signatures.sql
+++ b/db/schema/sqlite/20231113161726_tx-method-signatures.sql
@@ -3,15 +3,11 @@
 
 CREATE TABLE IF NOT EXISTS "tx_function_signatures"
 (
-    "signature" TEXT NOT NULL,
     "bytes" BLOB NOT NULL,
+    "signature" TEXT NOT NULL,
     "name" TEXT NOT NULL,
-    PRIMARY KEY ("signature")
+    PRIMARY KEY ("bytes")
 );
-
-CREATE INDEX IF NOT EXISTS "tx_function_signatures_bytes_idx"
-    ON "tx_function_signatures" 
-    ("bytes" ASC);
 
 CREATE TABLE IF NOT EXISTS "tx_unknown_signatures"
 (

--- a/dbtypes/dbtypes.go
+++ b/dbtypes/dbtypes.go
@@ -111,3 +111,8 @@ type TxUnknownFunctionSignature struct {
 	Bytes     []byte `db:"bytes"`
 	LastCheck uint64 `db:"lastcheck"`
 }
+
+type TxPendingFunctionSignature struct {
+	Bytes     []byte `db:"bytes"`
+	QueueTime uint64 `db:"queuetime"`
+}

--- a/dbtypes/dbtypes.go
+++ b/dbtypes/dbtypes.go
@@ -100,3 +100,14 @@ type BlobAssignment struct {
 	Commitment []byte `db:"commitment"`
 	Slot       uint64 `db:"slot"`
 }
+
+type TxFunctionSignature struct {
+	Signature string `db:"signature"`
+	Bytes     []byte `db:"bytes"`
+	Name      string `db:"name"`
+}
+
+type TxUnknownFunctionSignature struct {
+	Bytes     []byte `db:"bytes"`
+	LastCheck uint64 `db:"lastcheck"`
+}

--- a/handlers/slot.go
+++ b/handlers/slot.go
@@ -13,6 +13,9 @@ import (
 	"time"
 
 	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/bellatrix"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/gorilla/mux"
 	"github.com/juliangruber/go-intersect"
 	"github.com/sirupsen/logrus"
@@ -32,6 +35,7 @@ func Slot(w http.ResponseWriter, r *http.Request) {
 	var slotTemplateFiles = append(layoutTemplateFiles,
 		"slot/slot.html",
 		"slot/overview.html",
+		"slot/transactions.html",
 		"slot/attestations.html",
 		"slot/deposits.html",
 		"slot/withdrawals.html",
@@ -485,21 +489,20 @@ func getSlotPageBlockData(blockData *services.CombinedBlockResponse, assignments
 			}
 			baseFeePerGas := new(big.Int).SetBytes(baseFeePerGasBEBytes[:])
 			pageData.ExecutionData = &models.SlotPageExecutionData{
-				ParentHash:        executionPayload.ParentHash[:],
-				FeeRecipient:      executionPayload.FeeRecipient[:],
-				StateRoot:         executionPayload.StateRoot[:],
-				ReceiptsRoot:      executionPayload.ReceiptsRoot[:],
-				LogsBloom:         executionPayload.LogsBloom[:],
-				Random:            executionPayload.PrevRandao[:],
-				GasLimit:          uint64(executionPayload.GasLimit),
-				GasUsed:           uint64(executionPayload.GasUsed),
-				Timestamp:         uint64(executionPayload.Timestamp),
-				Time:              time.Unix(int64(executionPayload.Timestamp), 0),
-				ExtraData:         executionPayload.ExtraData,
-				BaseFeePerGas:     baseFeePerGas.Uint64(),
-				BlockHash:         executionPayload.BlockHash[:],
-				BlockNumber:       uint64(executionPayload.BlockNumber),
-				TransactionsCount: uint64(len(executionPayload.Transactions)),
+				ParentHash:    executionPayload.ParentHash[:],
+				FeeRecipient:  executionPayload.FeeRecipient[:],
+				StateRoot:     executionPayload.StateRoot[:],
+				ReceiptsRoot:  executionPayload.ReceiptsRoot[:],
+				LogsBloom:     executionPayload.LogsBloom[:],
+				Random:        executionPayload.PrevRandao[:],
+				GasLimit:      uint64(executionPayload.GasLimit),
+				GasUsed:       uint64(executionPayload.GasUsed),
+				Timestamp:     uint64(executionPayload.Timestamp),
+				Time:          time.Unix(int64(executionPayload.Timestamp), 0),
+				ExtraData:     executionPayload.ExtraData,
+				BaseFeePerGas: baseFeePerGas.Uint64(),
+				BlockHash:     executionPayload.BlockHash[:],
+				BlockNumber:   uint64(executionPayload.BlockNumber),
 			}
 		case spec.DataVersionCapella:
 			if blockData.Block.Capella == nil {
@@ -512,21 +515,20 @@ func getSlotPageBlockData(blockData *services.CombinedBlockResponse, assignments
 			}
 			baseFeePerGas := new(big.Int).SetBytes(baseFeePerGasBEBytes[:])
 			pageData.ExecutionData = &models.SlotPageExecutionData{
-				ParentHash:        executionPayload.ParentHash[:],
-				FeeRecipient:      executionPayload.FeeRecipient[:],
-				StateRoot:         executionPayload.StateRoot[:],
-				ReceiptsRoot:      executionPayload.ReceiptsRoot[:],
-				LogsBloom:         executionPayload.LogsBloom[:],
-				Random:            executionPayload.PrevRandao[:],
-				GasLimit:          uint64(executionPayload.GasLimit),
-				GasUsed:           uint64(executionPayload.GasUsed),
-				Timestamp:         uint64(executionPayload.Timestamp),
-				Time:              time.Unix(int64(executionPayload.Timestamp), 0),
-				ExtraData:         executionPayload.ExtraData,
-				BaseFeePerGas:     baseFeePerGas.Uint64(),
-				BlockHash:         executionPayload.BlockHash[:],
-				BlockNumber:       uint64(executionPayload.BlockNumber),
-				TransactionsCount: uint64(len(executionPayload.Transactions)),
+				ParentHash:    executionPayload.ParentHash[:],
+				FeeRecipient:  executionPayload.FeeRecipient[:],
+				StateRoot:     executionPayload.StateRoot[:],
+				ReceiptsRoot:  executionPayload.ReceiptsRoot[:],
+				LogsBloom:     executionPayload.LogsBloom[:],
+				Random:        executionPayload.PrevRandao[:],
+				GasLimit:      uint64(executionPayload.GasLimit),
+				GasUsed:       uint64(executionPayload.GasUsed),
+				Timestamp:     uint64(executionPayload.Timestamp),
+				Time:          time.Unix(int64(executionPayload.Timestamp), 0),
+				ExtraData:     executionPayload.ExtraData,
+				BaseFeePerGas: baseFeePerGas.Uint64(),
+				BlockHash:     executionPayload.BlockHash[:],
+				BlockNumber:   uint64(executionPayload.BlockNumber),
 			}
 		case spec.DataVersionDeneb:
 			if blockData.Block.Deneb == nil {
@@ -534,22 +536,22 @@ func getSlotPageBlockData(blockData *services.CombinedBlockResponse, assignments
 			}
 			executionPayload := blockData.Block.Deneb.Message.Body.ExecutionPayload
 			pageData.ExecutionData = &models.SlotPageExecutionData{
-				ParentHash:        executionPayload.ParentHash[:],
-				FeeRecipient:      executionPayload.FeeRecipient[:],
-				StateRoot:         executionPayload.StateRoot[:],
-				ReceiptsRoot:      executionPayload.ReceiptsRoot[:],
-				LogsBloom:         executionPayload.LogsBloom[:],
-				Random:            executionPayload.PrevRandao[:],
-				GasLimit:          uint64(executionPayload.GasLimit),
-				GasUsed:           uint64(executionPayload.GasUsed),
-				Timestamp:         uint64(executionPayload.Timestamp),
-				Time:              time.Unix(int64(executionPayload.Timestamp), 0),
-				ExtraData:         executionPayload.ExtraData,
-				BaseFeePerGas:     executionPayload.BaseFeePerGas.Uint64(),
-				BlockHash:         executionPayload.BlockHash[:],
-				BlockNumber:       uint64(executionPayload.BlockNumber),
-				TransactionsCount: uint64(len(executionPayload.Transactions)),
+				ParentHash:    executionPayload.ParentHash[:],
+				FeeRecipient:  executionPayload.FeeRecipient[:],
+				StateRoot:     executionPayload.StateRoot[:],
+				ReceiptsRoot:  executionPayload.ReceiptsRoot[:],
+				LogsBloom:     executionPayload.LogsBloom[:],
+				Random:        executionPayload.PrevRandao[:],
+				GasLimit:      uint64(executionPayload.GasLimit),
+				GasUsed:       uint64(executionPayload.GasUsed),
+				Timestamp:     uint64(executionPayload.Timestamp),
+				Time:          time.Unix(int64(executionPayload.Timestamp), 0),
+				ExtraData:     executionPayload.ExtraData,
+				BaseFeePerGas: executionPayload.BaseFeePerGas.Uint64(),
+				BlockHash:     executionPayload.BlockHash[:],
+				BlockNumber:   uint64(executionPayload.BlockNumber),
 			}
+			getSlotPageTransactions(pageData, executionPayload.Transactions)
 		}
 	}
 
@@ -592,4 +594,39 @@ func getSlotPageBlockData(blockData *services.CombinedBlockResponse, assignments
 	}
 
 	return pageData
+}
+
+func getSlotPageTransactions(pageData *models.SlotPageBlockData, tranactions []bellatrix.Transaction) {
+	pageData.Transactions = make([]*models.SlotPageTransaction, 0)
+	for idx, txBytes := range tranactions {
+		var tx ethtypes.Transaction
+		err := rlp.DecodeBytes(txBytes, &tx)
+		if err != nil {
+			fmt.Printf("err: %v\n", err)
+			continue
+		}
+
+		txFrom, err := ethtypes.Sender(ethtypes.NewEIP155Signer(tx.ChainId()), &tx)
+		if err != nil {
+			txFrom, err = ethtypes.Sender(ethtypes.HomesteadSigner{}, &tx)
+		}
+		txHash := tx.Hash()
+
+		txValue := tx.Value()
+		txHighValue, _ := txValue.Div(txValue, utils.ETH).Float64()
+		txLowValue, _ := txValue.Mod(txValue, utils.ETH).Float64()
+		ethFloat, _ := utils.ETH.Float64()
+		txFloatValue := txHighValue + (txLowValue / ethFloat)
+
+		txData := &models.SlotPageTransaction{
+			Index: uint64(idx),
+			Hash:  txHash[:],
+			From:  txFrom.String(),
+			To:    tx.To().String(),
+			Value: txFloatValue,
+			Data:  tx.Data(),
+		}
+		pageData.Transactions = append(pageData.Transactions, txData)
+	}
+	pageData.TransactionsCount = uint64(len(tranactions))
 }

--- a/services/fnsignatures.go
+++ b/services/fnsignatures.go
@@ -143,7 +143,7 @@ func (tss *TxSignaturesService) LookupSignatures(sigBytes []types.TxSignatureByt
 	}
 
 	// add pending signature lookups
-	if len(unresolvedLookups) > 0 {
+	if len(unresolvedLookups) > 0 && !utils.Config.TxSignature.DisableLookupLoop {
 		pendingLookups := make([]*dbtypes.TxPendingFunctionSignature, 0)
 
 		for _, l := range unresolvedLookups {

--- a/services/fnsignatures.go
+++ b/services/fnsignatures.go
@@ -1,0 +1,252 @@
+package services
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"time"
+
+	nethttp "net/http"
+
+	"github.com/pk910/dora/db"
+	"github.com/pk910/dora/dbtypes"
+	"github.com/pk910/dora/utils"
+	"github.com/sirupsen/logrus"
+)
+
+type TxSignatureBytes [4]byte
+type TxSignatureLookupStatus uint8
+
+var (
+	TxSigStatusPending TxSignatureLookupStatus = 0
+	TxSigStatusFound   TxSignatureLookupStatus = 1
+	TxSigStatusUnknown TxSignatureLookupStatus = 2
+)
+
+type TxSignaturesService struct {
+	mutex           sync.Mutex
+	lookupMap       map[TxSignatureBytes]*TxSignaturesLookup
+	concurrencyChan chan bool
+}
+
+var GlobalTxSignaturesService *TxSignaturesService
+var logger_tss = logrus.StandardLogger().WithField("module", "txsig")
+
+type TxSignaturesLookup struct {
+	Bytes     []byte
+	Signature string
+	Name      string
+	Status    TxSignatureLookupStatus
+}
+
+// StartTxSignaturesService is used to start the global transaction signatures service
+func StartTxSignaturesService() error {
+	if GlobalTxSignaturesService != nil {
+		return nil
+	}
+
+	concurrencyLimit := utils.Config.TxSignature.ConcurrencyLimit
+	if concurrencyLimit == 0 {
+		concurrencyLimit = 10
+	}
+
+	GlobalTxSignaturesService = &TxSignaturesService{
+		lookupMap:       map[TxSignatureBytes]*TxSignaturesLookup{},
+		concurrencyChan: make(chan bool, concurrencyLimit),
+	}
+	return nil
+}
+
+func (tss *TxSignaturesService) LookupSignatures(sigBytes []TxSignatureBytes) map[TxSignatureBytes]*TxSignaturesLookup {
+	lookups := map[TxSignatureBytes]*TxSignaturesLookup{}
+	unresolvedLookups := make([]*TxSignaturesLookup, 0)
+	unresolvedLookupBytes := make([][]byte, 0)
+
+	tss.mutex.Lock()
+	for _, bytes := range sigBytes {
+		lookup := tss.lookupMap[bytes]
+		if lookup == nil {
+			lookup = &TxSignaturesLookup{
+				Bytes: bytes[:],
+			}
+			unresolvedLookups = append(unresolvedLookups, lookup)
+			unresolvedLookupBytes = append(unresolvedLookupBytes, bytes[:])
+		}
+		lookups[bytes] = lookup
+	}
+	tss.mutex.Unlock()
+
+	// check known signatures in DB
+	if len(unresolvedLookups) > 0 {
+		for _, dbSigEntry := range db.GetTxFunctionSignaturesByBytes(unresolvedLookupBytes) {
+			var lookup *TxSignaturesLookup
+			for i, l := range unresolvedLookups {
+				if bytes.Equal(l.Bytes, dbSigEntry.Bytes) {
+					lookup = l
+					unresolvedLookups[i] = nil
+					break
+				}
+			}
+			if lookup == nil {
+				break
+			}
+			lookup.Status = TxSigStatusFound
+			lookup.Signature = dbSigEntry.Signature
+			lookup.Name = dbSigEntry.Name
+		}
+
+		nonfoundLookups := make([]*TxSignaturesLookup, 0)
+		nonfoundLookupBytes := make([][]byte, 0)
+		for _, l := range unresolvedLookups {
+			if l == nil {
+				break
+			}
+			nonfoundLookups = append(nonfoundLookups, l)
+			nonfoundLookupBytes = append(nonfoundLookupBytes, l.Bytes)
+		}
+		unresolvedLookups = nonfoundLookups
+		unresolvedLookupBytes = nonfoundLookupBytes
+	}
+
+	// check unknown signatures in DB (previous failed sig lookups)
+	if len(unresolvedLookups) > 0 {
+		recheckTime := int64(utils.Config.TxSignature.RecheckTimeout.Seconds())
+		if recheckTime == 0 {
+			recheckTime = 86400
+		}
+		checkTimeout := time.Now().Unix() - recheckTime
+
+		for _, unknownSigEntry := range db.GetUnknownFunctionSignatures(unresolvedLookupBytes) {
+			if unknownSigEntry.LastCheck < uint64(checkTimeout) {
+				break
+			}
+
+			var lookup *TxSignaturesLookup
+			for i, l := range unresolvedLookups {
+				if bytes.Equal(l.Bytes, unknownSigEntry.Bytes) {
+					lookup = l
+					unresolvedLookups[i] = nil
+					break
+				}
+			}
+			if lookup == nil {
+				break
+			}
+			lookup.Status = TxSigStatusUnknown
+		}
+
+		nonfoundLookups := make([]*TxSignaturesLookup, 0)
+		nonfoundLookupBytes := make([][]byte, 0)
+		for _, l := range unresolvedLookups {
+			if l == nil {
+				break
+			}
+			nonfoundLookups = append(nonfoundLookups, l)
+			nonfoundLookupBytes = append(nonfoundLookupBytes, l.Bytes)
+		}
+		unresolvedLookups = nonfoundLookups
+		unresolvedLookupBytes = nonfoundLookupBytes
+	}
+
+	// do signature lookups
+	if len(unresolvedLookups) > 0 {
+		wg := sync.WaitGroup{}
+		for _, lookup := range unresolvedLookups {
+			wg.Add(1)
+			go func(lookup *TxSignaturesLookup) {
+				tss.concurrencyChan <- true
+				defer func() {
+					wg.Done()
+					<-tss.concurrencyChan
+				}()
+
+				tss.lookupSignature(lookup)
+			}(lookup)
+		}
+		wg.Wait()
+
+		// store new lookup results to db
+		unknownSigs := []*dbtypes.TxUnknownFunctionSignature{}
+		resolvedSigs := []*dbtypes.TxFunctionSignature{}
+
+		for _, lookup := range unresolvedLookups {
+			if lookup.Status == TxSigStatusUnknown {
+				unknownSigs = append(unknownSigs, &dbtypes.TxUnknownFunctionSignature{
+					Bytes:     lookup.Bytes,
+					LastCheck: uint64(time.Now().Unix()),
+				})
+			} else if lookup.Status == TxSigStatusFound {
+				resolvedSigs = append(resolvedSigs, &dbtypes.TxFunctionSignature{
+					Bytes:     lookup.Bytes,
+					Signature: lookup.Signature,
+					Name:      lookup.Name,
+				})
+			}
+		}
+	}
+
+	return lookups
+}
+
+func (tss *TxSignaturesService) lookupSignature(lookup *TxSignaturesLookup) error {
+	if utils.Config.TxSignature.Enable4Bytes {
+		err := tss.lookup4Bytes(lookup)
+		if err != nil {
+			logger_tss.Warnf("tx signatures lookup from 4bytes failed: %v", err)
+		} else if lookup.Status == TxSigStatusFound {
+			return nil
+		}
+	}
+
+	return nil
+}
+
+type txSigLookup_4bytesResponse struct {
+	Count   int `json:"count"`
+	Results []struct {
+		Id        int    `json:"id"`
+		Signature string `json:"textsignature"`
+	} `json:"results"`
+}
+
+func (tss *TxSignaturesService) lookup4Bytes(lookup *TxSignaturesLookup) error {
+	// lookup signature via https://www.4byte.directory/
+	url := fmt.Sprintf("https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=0x%x", lookup.Bytes)
+
+	req, err := nethttp.NewRequest("GET", url, nil)
+	if err != nil {
+		return err
+	}
+	client := &nethttp.Client{Timeout: time.Second * 10}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != nethttp.StatusOK {
+		data, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("url: %v, code: %v, error-response: %s", url, resp.StatusCode, data)
+	}
+
+	returnValue := txSigLookup_4bytesResponse{}
+	dec := json.NewDecoder(resp.Body)
+	err = dec.Decode(&returnValue)
+	if err != nil {
+		return fmt.Errorf("error parsing 4bytes json response: %v", err)
+	}
+
+	if returnValue.Count == 0 {
+		lookup.Status = TxSigStatusUnknown
+	} else {
+		lookup.Status = TxSigStatusFound
+		lookup.Signature = returnValue.Results[0].Signature
+		sigparts := strings.Split(lookup.Signature, "(")
+		lookup.Name = sigparts[0]
+	}
+	return nil
+}

--- a/static/css/layout.css
+++ b/static/css/layout.css
@@ -296,3 +296,7 @@ span.validator-label {
 .table-sorting thead .sort-link:hover, .table-sorting thead .sort-link.active {
   opacity: 1;
 }
+
+.ellipsis-copy-btn {
+  float: right;
+}

--- a/templates/slot/overview.html
+++ b/templates/slot/overview.html
@@ -153,6 +153,7 @@
         {{ end }}
 
         {{ if .Block.ExecutionData }}
+          {{ $block := .Block }}
           {{ with .Block.ExecutionData }}
             <div class="row border-bottom p-2 mx-0">
               <div class="col-md-2"><span data-bs-toggle="tooltip" data-bs-placement="top" title="Received Eth Block headers and Deposit data">Execution Payload:</span></div>
@@ -200,7 +201,7 @@
 
                 <div class="row py-1">
                   <div class="col-md-2"><span data-bs-toggle="tooltip" data-bs-placement="top" title="Transactions">Transactions:</span></div>
-                  <div class="col-md-10 text-monospace text-break">{{ .TransactionsCount }}</div>
+                  <div class="col-md-10 text-monospace text-break">{{ $block.TransactionsCount }}</div>
                 </div>
 
                 <div class="row py-1">

--- a/templates/slot/slot.html
+++ b/templates/slot/slot.html
@@ -28,6 +28,11 @@
         <a class="nav-link active" id="overview-tab" data-bs-toggle="tab" href="#overview" role="tab" aria-controls="overview" aria-selected="true">Overview</a>
       </li>
       {{ if .Block }}
+        {{ if gt .Block.TransactionsCount 0 }}
+          <li class="nav-item">
+            <a class="nav-link" id="transactions-tab" data-bs-toggle="tab" href="#transactions" role="tab" aria-controls="transactions" aria-selected="false">Transactions <span class="badge bg-secondary text-white">{{ .Block.TransactionsCount }}</span></a>
+          </li>
+        {{ end }}
         <li class="nav-item">
           <a class="nav-link" id="attestations-tab" data-bs-toggle="tab" href="#attestations" role="tab" aria-controls="attestations" aria-selected="false">Attestations <span class="badge bg-secondary text-white">{{ .Block.AttestationsCount }}</span></a>
         </li>
@@ -76,6 +81,18 @@
         </div>
       </div>
       {{ if .Block }}
+        {{ if gt .Block.TransactionsCount 0 }}
+          <div class="tab-pane fade show active" id="transactions" role="tabpanel" aria-labelledby="transactions-tab">
+            <div class="card block-card">
+              <div style="margin-bottom: -.25rem;" class="card-body px-0 py-1">
+                <div class="row p-1 mx-0">
+                  <h3 class="h5 col-md-12 text-center"><b>Showing {{ .Block.TransactionsCount }} Transactions </b></h3>
+                </div>
+              </div>
+              {{ template "block_transactions" . }}
+            </div>
+          </div>
+        {{ end }}
         <div class="tab-pane fade show active" id="attestations" role="tabpanel" aria-labelledby="attestations-tab">
           <div class="card block-card">
             <div style="margin-bottom: -.25rem;" class="card-body px-0 py-1">

--- a/templates/slot/transactions.html
+++ b/templates/slot/transactions.html
@@ -9,6 +9,8 @@
           <th>To</th>
           <th>Method</th>
           <th>Value</th>
+          <th>Call Data</th>
+          <th></th>
         </tr>
       </thead>
       <tbody>
@@ -34,10 +36,26 @@
               {{ $transaction.To }}
             </td>
             <td>
-              {{ $transaction.FuncName }}
-
+              {{ if eq $transaction.FuncSigStatus 10 }}
+                <span class="badge rounded-pill text-bg-secondary" style="font-size: 12px; font-weight: 500;">{{ $transaction.FuncName }}</span>
+              {{ else if eq $transaction.FuncSigStatus 1 }}
+                <span class="badge rounded-pill text-bg-secondary" style="font-size: 12px; font-weight: 500;" data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-title="call {{ $transaction.FuncBytes }}: {{ $transaction.FuncSig }}">{{ $transaction.FuncName }}</span>
+              {{ else }}
+                <span class="badge rounded-pill text-bg-secondary" style="font-size: 12px; font-weight: 500;" data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-title="call {{ $transaction.FuncBytes }}">{{ $transaction.FuncName }}</span>
+              {{ end }}
             </td>
-            <td>{{ $transaction.Value }}</td>
+            <td>{{ $transaction.Value }} ETH</td>
+            <td>
+              {{ if gt $transaction.DataLen 0 }}
+                <span class="badge rounded-pill text-bg-secondary" style="font-size: 12px; font-weight: 500;">{{ $transaction.DataLen }} B</span>
+                <i class="fa fa-copy text-muted ml-2 p-1" role="button" data-bs-toggle="tooltip" title="Copy to clipboard" data-clipboard-text="0x{{ printf "%x" $transaction.Data }}"></i>
+              {{ end }}
+            </td>
+            <td>
+              <i class="fa fa-circle-info text-muted ml-2 p-1" role="button" data-bs-toggle="tooltip" data-bs-html="true" data-bs-title="{{ "" -}}
+                TX Type: {{ $transaction.Type }}<br>
+              {{- "" }}"></i>
+            </td>
           </tr>
         {{ end }}
       </tbody>

--- a/templates/slot/transactions.html
+++ b/templates/slot/transactions.html
@@ -33,7 +33,10 @@
               </div>
               {{ $transaction.To }}
             </td>
-            <td>?</td>
+            <td>
+              {{ $transaction.FuncName }}
+
+            </td>
             <td>{{ $transaction.Value }}</td>
           </tr>
         {{ end }}

--- a/templates/slot/transactions.html
+++ b/templates/slot/transactions.html
@@ -1,0 +1,43 @@
+{{ define "block_transactions" }}
+  <div class="table-ellipsis px-0">
+    <table class="table" id="block_transactions">
+      <thead>
+        <tr>
+          <th>#</th>
+          <th>Hash</th>
+          <th>From</th>
+          <th>To</th>
+          <th>Method</th>
+          <th>Value</th>
+        </tr>
+      </thead>
+      <tbody>
+        {{ range $i, $transaction := .Block.Transactions }}
+          <tr>
+            <td>{{ $i }}</td>
+            <td>
+              <div class="ellipsis-copy-btn">
+                <i class="fa fa-copy text-muted ml-2 p-1" role="button" data-bs-toggle="tooltip" title="Copy to clipboard" data-clipboard-text="0x{{ printf "%x" $transaction.Hash }}"></i>
+              </div>
+              0x{{ printf "%x" $transaction.Hash }}
+            </td>
+            <td>
+              <div class="ellipsis-copy-btn">
+                <i class="fa fa-copy text-muted ml-2 p-1" role="button" data-bs-toggle="tooltip" title="Copy to clipboard" data-clipboard-text="{{ $transaction.From }}"></i>
+              </div>
+              {{ $transaction.From }}
+            </td>
+            <td>
+              <div class="ellipsis-copy-btn">
+                <i class="fa fa-copy text-muted ml-2 p-1" role="button" data-bs-toggle="tooltip" title="Copy to clipboard" data-clipboard-text="{{ $transaction.To }}"></i>
+              </div>
+              {{ $transaction.To }}
+            </td>
+            <td>?</td>
+            <td>{{ $transaction.Value }}</td>
+          </tr>
+        {{ end }}
+      </tbody>
+    </table>
+  </div>
+{{ end }}

--- a/types/config.go
+++ b/types/config.go
@@ -91,6 +91,12 @@ type Config struct {
 		} `yaml:"aws"`
 	} `yaml:"blobstore"`
 
+	TxSignature struct {
+		Enable4Bytes     bool          `yaml:"enable4Bytes" envconfig:"TXSIG_ENABLE_4BYTES"`
+		RecheckTimeout   time.Duration `yaml:"recheckTimeout" envconfig:"TXSIG_RECHECK_TIMEOUT"`
+		ConcurrencyLimit uint64        `yaml:"concurrencyLimit" envconfig:"TXSIG_CONCURRENCY_LIMIT"`
+	} `yaml:"txsig"`
+
 	Database struct {
 		Engine string `yaml:"engine" envconfig:"DATABASE_ENGINE"`
 		Sqlite struct {

--- a/types/config.go
+++ b/types/config.go
@@ -96,7 +96,7 @@ type Config struct {
 		LookupInterval    time.Duration `yaml:"lookupInterval" envconfig:"TXSIG_LOOKUP_INTERVAL"`
 		LookupBatchSize   uint64        `yaml:"lookupBatchSize" envconfig:"TXSIG_LOOKUP_INTERVAL"`
 		ConcurrencyLimit  uint64        `yaml:"concurrencyLimit" envconfig:"TXSIG_CONCURRENCY_LIMIT"`
-		Enable4Bytes      bool          `yaml:"enable4Bytes" envconfig:"TXSIG_ENABLE_4BYTES"`
+		Disable4Bytes     bool          `yaml:"disable4Bytes" envconfig:"TXSIG_DISABLE_4BYTES"`
 		RecheckTimeout    time.Duration `yaml:"recheckTimeout" envconfig:"TXSIG_RECHECK_TIMEOUT"`
 	} `yaml:"txsig"`
 

--- a/types/config.go
+++ b/types/config.go
@@ -92,9 +92,12 @@ type Config struct {
 	} `yaml:"blobstore"`
 
 	TxSignature struct {
-		Enable4Bytes     bool          `yaml:"enable4Bytes" envconfig:"TXSIG_ENABLE_4BYTES"`
-		RecheckTimeout   time.Duration `yaml:"recheckTimeout" envconfig:"TXSIG_RECHECK_TIMEOUT"`
-		ConcurrencyLimit uint64        `yaml:"concurrencyLimit" envconfig:"TXSIG_CONCURRENCY_LIMIT"`
+		DisableLookupLoop bool          `yaml:"disableLookupLoop" envconfig:"TXSIG_DISABLE_LOOKUP_LOOP"`
+		LookupInterval    time.Duration `yaml:"lookupInterval" envconfig:"TXSIG_LOOKUP_INTERVAL"`
+		LookupBatchSize   uint64        `yaml:"lookupBatchSize" envconfig:"TXSIG_LOOKUP_INTERVAL"`
+		ConcurrencyLimit  uint64        `yaml:"concurrencyLimit" envconfig:"TXSIG_CONCURRENCY_LIMIT"`
+		Enable4Bytes      bool          `yaml:"enable4Bytes" envconfig:"TXSIG_ENABLE_4BYTES"`
+		RecheckTimeout    time.Duration `yaml:"recheckTimeout" envconfig:"TXSIG_RECHECK_TIMEOUT"`
 	} `yaml:"txsig"`
 
 	Database struct {

--- a/types/models/slot.go
+++ b/types/models/slot.go
@@ -55,6 +55,7 @@ type SlotPageBlockData struct {
 	BlobsCount             uint64                 `json:"blobs_count"`
 	DenyDutyLoading        bool                   `json:"deny_duties"`
 	DutiesLoaded           bool                   `json:"duties_loaded"`
+	TransactionsCount      uint64                 `json:"transactions_count"`
 
 	ExecutionData     *SlotPageExecutionData      `json:"execution_data"`
 	Attestations      []*SlotPageAttestation      `json:"attestations"`       // Attestations included in this block
@@ -65,24 +66,24 @@ type SlotPageBlockData struct {
 	BLSChanges        []*SlotPageBLSChange        `json:"bls_changes"`        // BLSChanges included in this block
 	Withdrawals       []*SlotPageWithdrawal       `json:"withdrawals"`        // Withdrawals included in this block
 	Blobs             []*SlotPageBlob             `json:"blobs"`              // Blob sidecars included in this block
+	Transactions      []*SlotPageTransaction      `json:"transactions"`       // Transactions included in this block
 }
 
 type SlotPageExecutionData struct {
-	ParentHash        []byte    `json:"parent_hash"`
-	FeeRecipient      []byte    `json:"fee_recipient"`
-	StateRoot         []byte    `json:"state_root"`
-	ReceiptsRoot      []byte    `json:"receipts_root"`
-	LogsBloom         []byte    `json:"logs_bloom"`
-	Random            []byte    `json:"random"`
-	GasLimit          uint64    `json:"gas_limit"`
-	GasUsed           uint64    `json:"gas_used"`
-	Timestamp         uint64    `json:"timestamp"`
-	Time              time.Time `json:"time"`
-	ExtraData         []byte    `json:"extra_data"`
-	BaseFeePerGas     uint64    `json:"base_fee_per_gas"`
-	BlockHash         []byte    `json:"block_hash"`
-	BlockNumber       uint64    `json:"block_number"`
-	TransactionsCount uint64    `json:"transactions_count"`
+	ParentHash    []byte    `json:"parent_hash"`
+	FeeRecipient  []byte    `json:"fee_recipient"`
+	StateRoot     []byte    `json:"state_root"`
+	ReceiptsRoot  []byte    `json:"receipts_root"`
+	LogsBloom     []byte    `json:"logs_bloom"`
+	Random        []byte    `json:"random"`
+	GasLimit      uint64    `json:"gas_limit"`
+	GasUsed       uint64    `json:"gas_used"`
+	Timestamp     uint64    `json:"timestamp"`
+	Time          time.Time `json:"time"`
+	ExtraData     []byte    `json:"extra_data"`
+	BaseFeePerGas uint64    `json:"base_fee_per_gas"`
+	BlockHash     []byte    `json:"block_hash"`
+	BlockNumber   uint64    `json:"block_number"`
 }
 
 type SlotPageAttestation struct {
@@ -185,4 +186,13 @@ type SlotPageBlobDetails struct {
 	Blob          string `json:"blob"`
 	KzgCommitment string `json:"kzg_commitment"`
 	KzgProof      string `json:"kzg_proof"`
+}
+
+type SlotPageTransaction struct {
+	Index uint64  `json:"index"`
+	Hash  []byte  `json:"hash"`
+	From  string  `json:"from"`
+	To    string  `json:"to"`
+	Value float64 `json:"value"`
+	Data  []byte  `json:"data"`
 }

--- a/types/models/slot.go
+++ b/types/models/slot.go
@@ -189,10 +189,13 @@ type SlotPageBlobDetails struct {
 }
 
 type SlotPageTransaction struct {
-	Index uint64  `json:"index"`
-	Hash  []byte  `json:"hash"`
-	From  string  `json:"from"`
-	To    string  `json:"to"`
-	Value float64 `json:"value"`
-	Data  []byte  `json:"data"`
+	Index         uint64  `json:"index"`
+	Hash          []byte  `json:"hash"`
+	From          string  `json:"from"`
+	To            string  `json:"to"`
+	Value         float64 `json:"value"`
+	Data          []byte  `json:"data"`
+	FuncSigStatus uint64  `json:"func_sig_status"`
+	FuncName      string  `json:"func_name"`
+	FuncSig       string  `json:"func_sig"`
 }

--- a/types/models/slot.go
+++ b/types/models/slot.go
@@ -195,7 +195,10 @@ type SlotPageTransaction struct {
 	To            string  `json:"to"`
 	Value         float64 `json:"value"`
 	Data          []byte  `json:"data"`
+	DataLen       uint64  `json:"datalen"`
 	FuncSigStatus uint64  `json:"func_sig_status"`
+	FuncBytes     string  `json:"func_bytes"`
 	FuncName      string  `json:"func_name"`
 	FuncSig       string  `json:"func_sig"`
+	Type          uint64  `json:"type"`
 }

--- a/types/txsig.go
+++ b/types/txsig.go
@@ -1,0 +1,10 @@
+package types
+
+type TxSignatureBytes [4]byte
+type TxSignatureLookupStatus uint8
+
+var (
+	TxSigStatusPending TxSignatureLookupStatus = 0
+	TxSigStatusFound   TxSignatureLookupStatus = 1
+	TxSigStatusUnknown TxSignatureLookupStatus = 2
+)

--- a/utils/constants.go
+++ b/utils/constants.go
@@ -1,0 +1,6 @@
+package utils
+
+import "math/big"
+
+var GWEI *big.Int = big.NewInt(1000000000)
+var ETH *big.Int = big.NewInt(0).Mul(GWEI, GWEI)


### PR DESCRIPTION
This PR adds a simple transaction list to the slot details page.

It's a simple view only. 
Transactions are not indexed or otherwise processed (no receipts, etc)